### PR TITLE
[Style] #41 마이페이지, 채팅 페이지 헤더 뒤로가기 버튼 제거

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -6,13 +6,14 @@ import { BangjjackTitleIcon, GoogleIcon, LogoLoginIcon } from "@/assets/icons";
 export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const redirectFrom = location.state?.from;
   const from = (location.state?.from?.pathname as string) ?? "/";
 
   useEffect(() => {
-    if (location.state?.from) {
+    if (redirectFrom) {
       toast.error("로그인이 필요합니다.");
     }
-  }, []);
+  }, [redirectFrom]);
 
   return (
     <div className="min-h-dvh bg-neutral-50">

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -23,12 +23,12 @@ const ROUTE_CONFIGS: RouteConfigEntry[] = [
   },
   {
     activeIcon: "chat",
-    header: { showBack: true, title: "채팅", variant: "title" },
+    header: { title: "채팅", variant: "title" },
     pattern: "/chat",
   },
   {
     activeIcon: "mypage",
-    header: { showBack: true, title: "마이페이지", variant: "title" },
+    header: { title: "마이페이지", variant: "title" },
     pattern: "/mypage",
   },
   {


### PR DESCRIPTION
## 🗒️ PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br>

## 🔗 관련 이슈

- close #41

<br>

## 📌 작업사항

- 채팅 첫 화면 헤더에서 뒤로가기 버튼 제거
- 마이페이지 첫 화면 헤더에서 뒤로가기 버튼 제거
- 마이페이지 하위 화면의 뒤로가기 버튼은 유지

<br>

## 📸 스크린샷

<img width="535" height="865" alt="image" src="https://github.com/user-attachments/assets/7d2b8684-ab19-443a-bc95-9f6a3d97fa2e" />
<img width="537" height="866" alt="image" src="https://github.com/user-attachments/assets/fe5e4063-c76e-4531-b3a2-79603e15e191" />


<br>

## 📣 기타사항 및 코멘트

- 간단한 수정이라 style로 타입을 정했습니다! 뒤로가기 버튼 제거하니 더 깔끔한 것 같네요👍

<br>

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [ ] Label 지정 완료
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 반영 완료