### PR TITLE
[Fix] #85 바텀시트 프로필카드에 필요한 정보 렌더링하도록 수정

### DIFF
--- a/src/features/board/utils/index.ts
+++ b/src/features/board/utils/index.ts
@@ -2,6 +2,9 @@ export { formatRelativeTime } from "@/utils";
 export { apiChecklistToFormState, formStateToApiChecklist } from "./mapChecklistData";
 export { mapFormToCreatePostRequest } from "./mapFormToCreatePostRequest";
 export {
+  BEDTIME_LABEL,
+  CLEANING_CYCLE_LABEL,
+  SMOKING_LABEL,
   computeChecklistMatchStats,
   mapLifestyleChecklistToEntries,
 } from "./mapLifestyleChecklistToEntries";

--- a/src/features/chat/components/chat-detail/ChatRoommateInviteSheet.tsx
+++ b/src/features/chat/components/chat-detail/ChatRoommateInviteSheet.tsx
@@ -12,12 +12,12 @@ import type { ChatUserProfile } from "@/features/chat/types";
 
 export type ChatRoommateInviteSheetProps = Pick<
   ChatUserProfile,
-  "age" | "department" | "nickname"
+  "age" | "department" | "nickname" | "profileImage"
 > & {
   avatarSeed?: number;
   className?: string;
   confirmDisabled?: boolean;
-  lifestyleTags: string[];
+  lifestyleTags?: string[];
   open: boolean;
   onCancel: () => void;
   onConfirm: () => void;
@@ -32,6 +32,7 @@ function ChatRoommateInviteSheet({
   lifestyleTags,
   nickname,
   open,
+  profileImage,
   onCancel,
   onConfirm,
 }: ChatRoommateInviteSheetProps) {
@@ -61,7 +62,7 @@ function ChatRoommateInviteSheet({
           </div>
 
           <div className="flex items-center gap-400 rounded-2xl border border-brand-primary bg-bg-secondary p-400">
-            <ProfileAvatar seed={avatarSeed ?? nickname.length} size={36} />
+            <ProfileAvatar imageUrl={profileImage} seed={avatarSeed ?? nickname.length} size={36} />
 
             <div className="min-w-0 flex-1">
               <p className="typo-title3 text-text-normal">{nickname}</p>
@@ -74,11 +75,13 @@ function ChatRoommateInviteSheet({
                 {department ? <span>{department}</span> : null}
               </div>
 
-              <div className="mt-100 flex flex-wrap gap-100">
-                {lifestyleTags.map((tag) => (
-                  <Tag key={tag}>{tag}</Tag>
-                ))}
-              </div>
+              {lifestyleTags && lifestyleTags.length > 0 && (
+                <div className="mt-100 flex flex-wrap gap-100">
+                  {lifestyleTags.map((tag) => (
+                    <Tag key={tag}>{tag}</Tag>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/features/chat/hooks/useChatDetailPage.ts
+++ b/src/features/chat/hooks/useChatDetailPage.ts
@@ -144,7 +144,6 @@ function useChatDetailPage() {
     ? { ...baseChatDetail, age, department, profileImage, lifestyleTags }
     : undefined;
 
-  console.log("[useChatDetailPage]", { age, department, profileImage, lifestyleTags });
   const recruitPostId =
     chatDetail?.startSource === "recruit_post" ? chatDetail.recruitPostId : undefined;
   const { data: recruitPost } = usePostDetail(recruitPostId);

--- a/src/features/chat/hooks/useChatDetailPage.ts
+++ b/src/features/chat/hooks/useChatDetailPage.ts
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useParams } from "react-router";
 
 import { DORMITORY_LABEL, ROOM_SIZE_LABEL, SEMESTER_LABEL } from "@/constants";
 import { usePostDetail } from "@/features/board/hooks";
+import { BEDTIME_LABEL, CLEANING_CYCLE_LABEL, SMOKING_LABEL } from "@/features/board/utils";
 import { toast } from "@/components/ui";
 import { useChatMessages } from "@/features/chat/hooks/useChatMessages";
 import { useChatRooms } from "@/features/chat/hooks/useChatRooms";
@@ -11,9 +12,11 @@ import { useProcessRoommateApplication } from "@/features/chat/hooks/useProcessR
 import type { ChatDetail, ChatMessage, ChatRoom, ChatRoomListItem } from "@/features/chat/types";
 import { mapHistoryMessagesToChatMessages } from "@/features/chat/utils/chatHistoryMessages";
 import { getChatRoomImportanceTags } from "@/features/chat/utils/chatRoomList";
+import { useUserProfile } from "@/features/user/hooks";
 import { getApiErrorMessage } from "@/lib/api-error";
 import { parseDisplayName } from "@/lib/parseDisplayName";
 import { useAuthStore } from "@/stores/authStore";
+import { getAgeFromBirthYear, parseDepartmentName } from "@/utils";
 
 export type ChatDetailPageState = {
   chatDetail?: ChatDetail;
@@ -117,9 +120,31 @@ function useChatDetailPage() {
   const chatRoomFromList = chatRoomsData?.rooms.find(
     (chatRoom) => chatRoom.roomId === parsedChatId,
   );
-  const chatDetail =
+  const baseChatDetail =
     locationState?.chatDetail ??
     (chatRoomFromList ? mapChatRoomListItemToChatDetail(chatRoomFromList) : undefined);
+
+  const { data: partnerProfile } = useUserProfile(baseChatDetail?.id ?? 0);
+
+  const age = partnerProfile ? getAgeFromBirthYear(partnerProfile.birthYear) : baseChatDetail?.age;
+  const department = partnerProfile
+    ? parseDepartmentName(partnerProfile.departmentName)
+    : baseChatDetail?.department;
+  const profileImage = partnerProfile?.profileImage ?? baseChatDetail?.profileImage;
+  const lifestyleTags = partnerProfile
+    ? [
+        `${BEDTIME_LABEL[partnerProfile.lifestyleChecklist.bedtime.value] ?? partnerProfile.lifestyleChecklist.bedtime.value} 취침`,
+        `${CLEANING_CYCLE_LABEL[partnerProfile.lifestyleChecklist.cleaningCycle.value] ?? partnerProfile.lifestyleChecklist.cleaningCycle.value} 청소`,
+        SMOKING_LABEL[partnerProfile.lifestyleChecklist.smoking.value] ??
+          partnerProfile.lifestyleChecklist.smoking.value,
+      ]
+    : baseChatDetail?.lifestyleTags;
+
+  const chatDetail: ChatDetail | undefined = baseChatDetail
+    ? { ...baseChatDetail, age, department, profileImage, lifestyleTags }
+    : undefined;
+
+  console.log("[useChatDetailPage]", { age, department, profileImage, lifestyleTags });
   const recruitPostId =
     chatDetail?.startSource === "recruit_post" ? chatDetail.recruitPostId : undefined;
   const { data: recruitPost } = usePostDetail(recruitPostId);
@@ -136,18 +161,20 @@ function useChatDetailPage() {
     roomId: Number.isNaN(parsedChatId) ? undefined : parsedChatId,
   });
 
+  const hasChatDetail = !!chatDetail;
+
   useEffect(() => {
     if (Number.isNaN(parsedChatId)) {
       navigate("/chat", { replace: true });
       return;
     }
 
-    if (chatDetail || isChatRoomsPending) {
+    if (hasChatDetail || isChatRoomsPending) {
       return;
     }
 
     navigate("/chat", { replace: true });
-  }, [chatDetail, isChatRoomsPending, navigate, parsedChatId]);
+  }, [hasChatDetail, isChatRoomsPending, navigate, parsedChatId]);
 
   useEffect(() => {
     if (isChatRoomsError) {

--- a/src/features/chat/sections/chat-detail/ChatInputSection.tsx
+++ b/src/features/chat/sections/chat-detail/ChatInputSection.tsx
@@ -86,6 +86,7 @@ function ChatInputSection({
         department={chatDetail.department}
         lifestyleTags={chatDetail.lifestyleTags ?? chatDetail.profileSummary}
         nickname={chatDetail.nickname}
+        profileImage={chatDetail.profileImage}
         open={inviteSheet.open}
         confirmDisabled={inviteSheet.isSendingInviteRequest ?? false}
         onCancel={inviteSheet.onClose}

--- a/src/pages/chat/ChatListPage.tsx
+++ b/src/pages/chat/ChatListPage.tsx
@@ -66,7 +66,7 @@ function ChatTabContent({ tab }: { tab: ChatTab }) {
 
   if (isError) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <p className="typo-body2 text-text-caption">채팅방 목록을 불러오지 못했어요.</p>
       </div>
     );
@@ -84,7 +84,7 @@ function ChatTabContent({ tab }: { tab: ChatTab }) {
 
   if (chatRooms.length === 0) {
     return (
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <p className="typo-body2 text-text-caption">아직 채팅방이 없어요.</p>
       </div>
     );
@@ -122,7 +122,7 @@ export default function ChatListPage() {
   useChatRoomListRealtime();
 
   return (
-    <div className={cn("flex min-h-full flex-col pt-100")}>
+    <div className={cn("flex h-full flex-col pt-100")}>
       <section className="flex min-h-0 flex-1 flex-col rounded-medium bg-bg-secondary px-300 pb-100">
         <div className="relative flex border-b border-border-normal">
           <div
@@ -172,7 +172,7 @@ export default function ChatListPage() {
                   aria-labelledby={`tab-${tab.key}`}
                   aria-hidden={!isActive}
                   inert={!isActive}
-                  className="flex h-full flex-col overflow-y-auto"
+                  className="flex flex-1 flex-col overflow-y-auto"
                   style={{ width: `${100 / CHAT_TABS.length}%` }}
                 >
                   <ChatTabContent tab={tab.key} />


### PR DESCRIPTION
## 🗒️ PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br>

## 🔗 관련 이슈

- close #85 

<br>

## 📌 작업사항

- 요청 보내기 바텀시트 프로필 카드의 라이프스타일 태그를 취침시간·청소 주기·흡연여부 3개 고정 항목으로 변경
- 취침시간은 {값} 취침, 청소 주기는 {값} 청소 형식으로 표시, 흡연여부는 - 값 그대로 표시
- 라이프스타일 태그 데이터가 없을 경우 태그 영역 미렌더링 처리
- 요청 보내기 바텀시트 프로필 카드에 프로필 이미지 표시 추가
- 채팅방 목록 비었을 때 문구 위치 버그 해결

<br>

## 📸 스크린샷
<img width="543" height="397" alt="스크린샷 2026-05-31 052942" src="https://github.com/user-attachments/assets/a8fbdc41-857d-4d18-9273-d68c507ac3e1" />




<br>

## 📣 기타사항 및 코멘트

라이프스타일 태그는 따로 받아오는 곳이 없어서 그냥 프로필 조회 API 쓰고 값만 가공했습니다! 랜덤으로 가져오기엔 너무 변수가 많을 것 같아서 취침시간, 청소 주기, 흡연 여부 3가지 항목만 보이도록 구현했습니다!

<br>

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [x] Label 지정 완료
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 반영 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채팅 상세 페이지에서 프로필 이미지 표시 추가

* **Bug Fixes**
  * 라이프스타일 태그가 없을 때 표시 오류 개선

* **Style**
  * 채팅 목록 페이지 레이아웃 스크롤 동작 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bangjjack/Bangjjack-Frontend/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->